### PR TITLE
Make the buildpack work with official Heroku multiple buildpacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,24 @@
 # ssh-private-key-buildpack
 
-A heroku buildpack for setting the ssh private key as part of the application build. It's meant to be used with [heroku-buildpack-multi](https://github.com/heroku/heroku-buildpack-multi), before other buildpacks which require the key to be present, like installing private `npm` modules from `github`.
+A Heroku buildpack for setting the ssh private key as part of the application build. It's meant to be used as part of a setup [using multiple buildpacks](https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app), so other buildpacks can authenticate with hosts using ssh keys, for instance to install dependencies from private git repositories.
 
 # Example usage
 
-Upload the private key to heroku (note that the key needs to be base64 encoded).
+Add the buildpack to your Heroku app. In the example below the `ssh-private-key-buildpack` runs before the `heroku/go` buildpack.
 
 ```
-heroku config:set SSH_KEY=$(cat ~/.ssh/id_rsa | base64)
+heroku buildpacks:set --index 1 https://github.com/debitoor/ssh-private-key-buildpack.git
+heroku buildpacks:add heroku/go
 ```
 
-Add a `.buildpacks` file (used by `heroku-buildpack-multi`) which contains this and the default node.js buildpack.
+Set the private key environment variable `SSH_KEY` of your Heroku app (note that the key needs to be base64 encoded).
 
 ```
-https://github.com/debitoor/ssh-private-key-buildpack.git#v1.0.0
-https://github.com/heroku/heroku-buildpack-nodejs.git#v75
+heroku config:set SSH_KEY=$(cat path/to/your/keys/id_rsa | base64)
 ```
 
-Now as long as the public key is present on github and the user has the correct permissions, it's possible to install `npm` modules from private `githup` repositories.
+By default the buildback adds Github to the `known_hosts`. However you can configure your app to add custom hosts, too. All that's needed is the set `SSH_HOSTS` for you app to a comma-separated list of hosts, e.g. ``
+
+```
+heroku config:set SSH_HOSTS="git@github.com,example.com"
+```

--- a/README.md
+++ b/README.md
@@ -4,21 +4,29 @@ A Heroku buildpack for setting the ssh private key as part of the application bu
 
 # Example usage
 
-Add the buildpack to your Heroku app. In the example below the `ssh-private-key-buildpack` runs before the `heroku/go` buildpack.
+## Configure Multiple Buildpacks
+### _Option 1:_ Heroku CLI or Dashboard
+Add the buildpack to your Heroku app either using the CLI or the Heroku dashboard. The `ssh-private-key-buildpack` needs to run before any buildpack trying to get ssh access. In the following example, it runs before the `heroku/go` buildpack.
 
-```
-heroku buildpacks:set --index 1 https://github.com/debitoor/ssh-private-key-buildpack.git
-heroku buildpacks:add heroku/go
-```
+    $ heroku buildpacks:set --index 1 https://github.com/debitoor/ssh-private-key-buildpack.git
+    $ heroku buildpacks:add heroku/go
+
+### _Option 2:_ Use `heroku-buildpack-multi`
+Instead of setting the buildpacks directly with Heroku they can also be configured using a `.buildpacks` in combination with [`heroku-buildpack-multi`]( https://github.com/heroku/heroku-buildpack-multi).
+
+    $ heroku buildpacks:set https://github.com/heroku/heroku-buildpack-multi.git  
+The same example given for the CLI use would have the following `.buildpacks` file.
+
+    $ cat .buildpacks
+    https://github.com/debitoor/ssh-private-key-buildpack.git
+    https://github.com/heroku/heroku-buildpack-go
+
+## Configure SSH Key
 
 Set the private key environment variable `SSH_KEY` of your Heroku app (note that the key needs to be base64 encoded).
 
-```
-heroku config:set SSH_KEY=$(cat path/to/your/keys/id_rsa | base64)
-```
+    $ heroku config:set SSH_KEY=$(cat path/to/your/keys/id_rsa | base64)
 
-By default the buildback adds Github to the `known_hosts`. However you can configure your app to add custom hosts, too. All that's needed is the set `SSH_HOSTS` for you app to a comma-separated list of hosts, e.g. ``
+By default the buildback adds Github to `known_hosts`. However you can configure your app to allow custom hosts, too. All that's needed is the set `SSH_HOSTS` for you app to a comma-separated list of hosts, e.g. `git@github.com,example.com`
 
-```
-heroku config:set SSH_HOSTS="git@github.com,example.com"
-```
+    $ heroku config:set SSH_HOSTS="git@github.com,example.com"

--- a/bin/compile
+++ b/bin/compile
@@ -8,15 +8,24 @@ function indent() {
 	esac
 }
 
-env_dir=$3
-ssh_key="$(cat $env_dir/SSH_KEY)"
+ENV_DIR=${3:-}
+ssh_key="$(cat $ENV_DIR/SSH_KEY)"
+ssh_hosts=${SSH_HOSTS:-"git@github.com"}
 
 if [ "$ssh_key" != "" ]; then
 	echo "-----> Running SSH private key setup"
 
-	mkdir "$HOME/.ssh"
+	# The .ssh needs to be located in the home directory which is different to the
+	# home directory of the built machine. The symlink resolves the issue.
+	mkdir "$1/.ssh"
+	ln -s "$1/.ssh" "$HOME/.ssh"
 	echo "$ssh_key" | base64 --decode > "$HOME/.ssh/id_rsa"
-	ssh -oStrictHostKeyChecking=no -T git@github.com 2>&1 | indent
+
+	IFS=',' read -ra HOST <<< "$ssh_hosts"
+	for i in "${HOST[@]}"; do
+		ssh -oStrictHostKeyChecking=no -T $i 2>&1 | indent
+	done
+
 	exit 0
 else
 	echo "-----> No SSH private key"


### PR DESCRIPTION
To allow the buildpack to be used with other buildpacks the way Heroku recommends, see https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app, the compile step now creates an `.ssh` directory in the `BUILD_DIR` and only sym-links to it for the duration of the buildpack compilation.

Furthermore, this version includes a way to customise the hosts that should be set up for `ssh` by using an environment variable. By default it's connecting to github.com as before. This should remove the need to fork the repository for most cases.
