### PR TITLE
Refactor the implementation of compile file to more explicitly log non-Github hosts and verify environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,15 @@ Set the private key environment variable `SSH_KEY` of your Heroku app (note that
 By default the buildback adds Github to `known_hosts`. However you can configure your app to allow custom hosts, too. All that's needed is the set `SSH_HOSTS` for you app to a comma-separated list of hosts, e.g. `git@github.com,example.com`
 
     $ heroku config:set SSH_HOSTS="git@github.com,example.com"
+
+## Additonal Hosts For Private Key (For use with non-Github private repositories)
+
+To associate additional hosts with the private key -- for example, bitbucket -- set the environment variable
+`SSH_HOSTS` to a comma-separated list of `[username]:host`.
+
+For example, to associate the key with only Bitbucket, the SSH_HOSTS variable would be: `SSH_HOSTS=git@bitbucket.org`.
+To associate multiple hosts (e.g. Github and Bitbucket), set `SSH_HOSTS=git@github.org,git@bitbucket.org`
+
+This can be done in the Heroku console, or via the Toolbelt CLI with:
+
+    $ heroku config:set SSH_HOSTS="git@github.com,example.com,git@bitbucket.org"

--- a/bin/compile
+++ b/bin/compile
@@ -9,24 +9,38 @@ function indent() {
 }
 
 ENV_DIR=${3:-}
-ssh_key="$(cat $ENV_DIR/SSH_KEY)"
-ssh_hosts=${SSH_HOSTS:-"git@github.com"}
-
-if [ "$ssh_key" != "" ]; then
-	echo "-----> Running SSH private key setup"
-
-	# The .ssh needs to be located in the home directory which is different to the
-	# home directory of the built machine. The symlink resolves the issue.
-	mkdir "$1/.ssh"
-	ln -s "$1/.ssh" "$HOME/.ssh"
-	echo "$ssh_key" | base64 --decode > "$HOME/.ssh/id_rsa"
-
-	IFS=',' read -ra HOST <<< "$ssh_hosts"
-	for i in "${HOST[@]}"; do
-		ssh -oStrictHostKeyChecking=no -T $i 2>&1 | indent
-	done
-
-	exit 0
-else
-	echo "-----> No SSH private key"
+# Notify the user if no SSH_KEY is set. If the key is not present we exit successfully (status code of 0),
+# though this means that this build back really does no work.
+if [[ ( ! -e "${ENV_DIR}/SSH_KEY" ) || ( "$(cat $ENV_DIR/SSH_KEY)" == "" )  ]]
+then
+    echo "-----> No SSH private key SSH_KEY environment variable found."
+    echo "-----> WARNING: If not setting the SSH_KEY was intentional, disregard this message. Otherwise, "\
+         "set the  SSH_KEY environment variable to the base64 encoded private key"
+    echo "-----> Proceeding to exit the build successfully."
+    exit 0
 fi
+SSH_PRIVATE_KEY="$(cat $ENV_DIR/SSH_KEY)"
+# Check for user-provided SSH_HOSTS. Default is github.org, but the user can provide a and environment
+# varibable SSH_HOSTS that is a comma-delimited string of hosts to associate the SSH key with
+if [[ ( -e "${ENV_DIR}/SSH_HOSTS" ) && ( "$(cat $ENV_DIR/SSH_HOSTS)" != "" ) ]]; then
+    SSH_HOSTS="$(cat $ENV_DIR/SSH_HOSTS)"
+    SSH_HOSTS_ARRAY=(${SSH_HOSTS//,/ })
+    echo "-----> User provided SSH_HOSTS have been identified. The ${#SSH_HOSTS_ARRAY[@]} hosts are: ${SSH_HOSTS_ARRAY[@]}"
+else
+    SSH_HOSTS_ARRAY=("git@github.com")
+    echo "-----> No provided SSH_HOSTS provided, so adding only the default host of ${SSH_HOSTS_ARRAY[@]}."
+fi
+
+
+echo "-----> Running SSH private key setup"
+# The .ssh needs to be located in the home directory which is different to the
+# home directory of the built machine. The symlink resolves the issue.
+mkdir "$1/.ssh"
+ln -s "$1/.ssh" "$HOME/.ssh"
+echo "$SSH_PRIVATE_KEY" | base64 --decode > "$HOME/.ssh/id_rsa"
+
+for hostname in "${SSH_HOSTS_ARRAY[@]}"; do
+    echo "Ading host ${hostname} to the allowed hosts config"
+	ssh -oStrictHostKeyChecking=no -T $hostname 2>&1 | indent
+done
+exit 0


### PR DESCRIPTION
Updates the implementation of compile for readability and more helpful logging messages. Also adds section on the README to help non-Github private repo owners figure out how to add Bitbucket as a host associated with the private key. 
