### PR TITLE
Key permissions are too open: Set correct permissions

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -20,6 +20,7 @@ if [ "$ssh_key" != "" ]; then
 	mkdir "$1/.ssh"
 	ln -s "$1/.ssh" "$HOME/.ssh"
 	echo "$ssh_key" | base64 --decode > "$HOME/.ssh/id_rsa"
+	chmod 0600 "$HOME/.ssh/id_rsa"
 
 	IFS=',' read -ra HOST <<< "$ssh_hosts"
 	for i in "${HOST[@]}"; do


### PR DESCRIPTION
I was trying to use the buildpack on [scalingo](https://scalingo.com), which also uses the same buildpack technology as Heroku. However, the application container has a different default `umask` than the containers on Heroku have.

**Heroku:**
```
> heroku run bash
~ $ umask   
0077
```

**Scalingo:**
```
> scalingo run bash
[11:19] Scalingo ~ $ umask
0022
```

Therefore, the permissions of the private ssh key file `~/.ssh/id_rsa` are too open resulting into the following error during build:

```
       @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
       @         WARNING: UNPROTECTED PRIVATE KEY FILE!          @
       @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
       Permissions 0664 for '/app/.ssh/id_rsa' are too open.
       It is required that your private key files are NOT accessible by others.
       This private key will be ignored.
       bad permissions: ignore key: /app/.ssh/id_rsa
```

**Fix:**
Change the permissions of the `~/.ssh/id_rsa` file after creation to 0600. 