### PR TITLE
Access SSH hosts from env dir

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -10,7 +10,9 @@ function indent() {
 
 ENV_DIR=${3:-}
 ssh_key="$(cat $ENV_DIR/SSH_KEY)"
-ssh_hosts=${SSH_HOSTS:-"git@github.com"}
+ssh_hosts="$(cat $ENV_DIR/SSH_HOSTS)"
+ssh_hosts=${ssh_hosts:-"git@github.com"}
+echo "Using host: $ssh_hosts"
 
 if [ "$ssh_key" != "" ]; then
 	echo "-----> Running SSH private key setup"

--- a/bin/compile
+++ b/bin/compile
@@ -12,7 +12,7 @@ ENV_DIR=${3:-}
 ssh_key="$(cat $ENV_DIR/SSH_KEY)"
 ssh_hosts="$(cat $ENV_DIR/SSH_HOSTS)"
 ssh_hosts=${ssh_hosts:-"git@github.com"}
-echo "Using host: $ssh_hosts"
+echo "Using hosts: $ssh_hosts"
 
 if [ "$ssh_key" != "" ]; then
 	echo "-----> Running SSH private key setup"


### PR DESCRIPTION
This allows the user to specify hosts if desired, and still fall back to github.com if not specified. Fixes #16 